### PR TITLE
Create a base image without gcloud and save one GB

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,9 +40,18 @@ jobs:
         [ "${GITHUB_EVENT_NAME}" == 'release' ] && echo "tag=${GITHUB_REF##*/}" >> $GITHUB_ENV || true
         [ "${GITHUB_EVENT_NAME}" == 'push' ] && echo "tag=latest" >> $GITHUB_ENV || true
 
-    - name: Build and push image
-      uses: docker/build-push-action@v5
+    - name: Build and push base image
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: true
-        tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.tag }}
+        tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.tag }}-base
+        target: base
+
+    - name: Build and push gcloud image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: true
+        tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.tag }}-gcloud
+        target: gcloud


### PR DESCRIPTION
## Description

Some user host everything on-premise and doesn't need `gcloud`.

```
$ docker image ls
REPOSITORY   TAG     IMAGE ID       CREATED          SIZE
gcloud       latest  ca1c4fcb3e81   18 minutes ago   1.98GB
base         latest  245b6afd93e5   19 minutes ago   923MB
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->


## Release Notes

### Required Actions

```ACTIONS_REQUIRED
The image has been divided into two separate images. The base image no longer includes `gcloud` and is labeled with the suffix `-base`, while the gcloud image is labeled with the suffix `-gcloud`.
```
