### PR TITLE
Add metalstack.cloud CLI.

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Log in to the Container registry
       uses: docker/login-action@v3
@@ -52,11 +52,11 @@ jobs:
         tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.tag }}-minimal
         target: minimal
 
-    - name: Build and push gcloud image
+    - name: Build and push image
       uses: docker/build-push-action@v6
       with:
         context: .
         push: true
         sbom: true
         tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.tag }}
-        target: gcloud
+        target: withcloudproviders

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,13 +38,17 @@ COPY gai.conf /etc/gai.conf
 
 ENTRYPOINT []
 
-FROM minimal AS gcloud
+FROM minimal AS withcloudproviders
 
-ENV CLOUD_SDK_VERSION=530.0.0
+ENV METAL_STACK_CLOUD_CLI_VERSION=v0.5.2 \
+ CLOUD_SDK_VERSION=530.0.0 \
+ PATH=/google-cloud-sdk/bin:$PATH
 
-ENV PATH=/google-cloud-sdk/bin:$PATH
-
-RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
+RUN curl -LO https://github.com/metal-stack-cloud/cli/releases/download/${METAL_STACK_CLOUD_CLI_VERSION}/metal-linux-amd64 \
+ && chmod +x metal-linux-amd64 \
+ && mv metal-linux-amd64 /usr/local/bin/metal \
+ && metal --version \
+ && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
  && tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
  && rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
  && gcloud config set core/disable_usage_reporting true \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENTRYPOINT []
 
 FROM minimal AS withcloudproviders
 
-ENV METAL_STACK_CLOUD_CLI_VERSION=v0.5.2 \
+ENV METAL_STACK_CLOUD_CLI_VERSION=v0.5.3 \
  CLOUD_SDK_VERSION=530.0.0 \
  PATH=/google-cloud-sdk/bin:$PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENTRYPOINT []
 
 FROM minimal AS withcloudproviders
 
-ENV METAL_STACK_CLOUD_CLI_VERSION=v0.5.3 \
+ENV METAL_STACK_CLOUD_CLI_VERSION=v0.5.4 \
  CLOUD_SDK_VERSION=530.0.0 \
  PATH=/google-cloud-sdk/bin:$PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENTRYPOINT []
 
 FROM minimal AS withcloudproviders
 
-ENV METAL_STACK_CLOUD_CLI_VERSION=v0.5.4 \
+ENV METAL_STACK_CLOUD_CLI_VERSION=v0.5.5 \
  CLOUD_SDK_VERSION=530.0.0 \
  PATH=/google-cloud-sdk/bin:$PATH
 


### PR DESCRIPTION
## Description

Currently, we require static service accounts to deploy applications on clusters provided metalstack.cloud. Like gcloud, it we should include the metalstack.cloud CLI and then use it to create short-lived tokens for CI deployments.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
